### PR TITLE
Expose read length settings to allow other analysis of other amplicon regions.

### DIFF
--- a/docs/2usage.md
+++ b/docs/2usage.md
@@ -138,6 +138,12 @@ Each step in the pipeline has a default set of requirements for number of CPUs, 
 
 <!-- TODO nf-core: Describe any other command line flags here -->
 
+#### `--min_read_length`
+Minimum length of reads (bp) used in analysis.
+
+#### `--max_read_length`
+Maximum length of reads (bp) used in analysis.
+
 #### `--outdir`
 The output directory where the results will be saved.
 

--- a/main.nf
+++ b/main.nf
@@ -28,6 +28,9 @@ def helpMessage() {
       --umap_set_size               Number of reads used to perform the UMAP+HDBSCAN clustering (100000)
       --cluster_sel_epsilon         Minimun distance to separate clusters. (0.5)
       --min_cluster_size            Minimum number of reads to call a independent cluster (100)
+      --min_read_length             Minimum number of base pair in sequence reads (1400)
+      --max_read_length             Maximum number of base pair in sequence reads (1700)
+
 
     Other options:
       --demultiplex                 Set this parameter if you file is a pooled sample
@@ -198,7 +201,7 @@ process QC {
     script:
     """
     barcode=${reads.baseName}
-    fastp -i $reads -q 8 -l 1400 --length_limit 1700 -o \$barcode\\_qced_reads.fastq
+    fastp -i $reads -q 8 -l ${params.min_read_length} --length_limit ${params.max_read_length} -o \$barcode\\_qced_reads.fastq
     #perl prinseq-lite.pl -fastq $reads -out_good qced_reads -min_len 1400 -max_len 1700 -log qc_log -min_qual_mean 8
     head -n\$(( ${params.umap_set_size}*4 )) \$barcode\\_qced_reads.fastq > \$barcode\\_qced_reads_set.fastq
     """

--- a/main.nf
+++ b/main.nf
@@ -31,7 +31,6 @@ def helpMessage() {
       --min_read_length             Minimum number of base pair in sequence reads (1400)
       --max_read_length             Maximum number of base pair in sequence reads (1700)
 
-
     Other options:
       --demultiplex                 Set this parameter if you file is a pooled sample
       --demultiplex_porechop        Same as --demultiplex but uses Porechop for the task

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,8 @@ params {
   cluster_sel_epsilon = 0.5
   min_cluster_size = 50
   polishing_reads = 100
+  min_read_length = 1400
+  max_read_length = 1700
 
   // Classification parameters
   db = false


### PR DESCRIPTION
# nf-core/nanoclust pull request

Many thanks for contributing to nf-core/nanoclust!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

This PR adds possibility to set minimum and maximum read length. This will allow users to use other amplicons than full length 16S, such ass 16S-23S or 18S. 


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Documentation in `docs` is updated


**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/nanoclust/tree/master/.github/CONTRIBUTING.md)