### PR TITLE
Interpret paths from blast db arguments

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -411,6 +411,17 @@ if(params.multiqc){
 
  }
 
+ def resolve_blast_db_path (path) {
+     if(path ==~ /^\/.*/)
+         path
+     else if(path ==~ /^\.\/.*/)
+         "$projectDir/" + path
+     else if(workflow.profile == 'conda' || workflow.profile == 'test,conda')
+         "$baseDir/" + path
+     else
+         "/tmp/" + path
+ }
+
  process consensus_classification {
      publishDir "${params.outdir}/${barcode}/cluster${cluster_id}", mode: 'copy', pattern: 'consensus_classification.csv'
      time '3m'
@@ -425,14 +436,8 @@ if(params.multiqc){
      tuple val(barcode), file('*_blast.log') into classifications_ch
 
      script:
-     if(workflow.profile == 'conda' || workflow.profile == 'test,conda'){
-         blast_dir = "$baseDir/"
-     }
-     else {
-         blast_dir = "/tmp/"
-     }
-     db=blast_dir + params.db
-     taxdb=blast_dir + params.tax
+     db = resolve_blast_db_path(params.db)
+     taxdb = resolve_blast_db_path(params.tax)
 
      if(!params.db)
         """


### PR DESCRIPTION
# nf-core/nanoclust pull request

Many thanks for contributing to nf-core/nanoclust!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/nanoclust branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/nanoclust)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/nanoclust/tree/master/.github/CONTRIBUTING.md)

These changes allow passing an actual absolute or relative path starting with `/` or `./` to the `--db` and `--tax` arguments. Relative paths will be resolved against the `$projectDir` directory.
Argument values that do not start with `/` or `./` will be resolved as usual.